### PR TITLE
Added logger.js file to allow you to only import the logger

### DIFF
--- a/logger.js
+++ b/logger.js
@@ -1,0 +1,1 @@
+module.exports = require("./lib/ut").logger;


### PR DESCRIPTION
var ut = require('ut')
var log = ut.logger;
or
var log = require('ut').logger;
becomes
var log = require('ut/logger');